### PR TITLE
fix: sort the nondeterministic arrays

### DIFF
--- a/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java
+++ b/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java
@@ -1047,7 +1047,8 @@ final class TestParameterAnnotationMethodProcessor implements TestMethodProcesso
           for (TestParameterValueHolder testParameterValue :
               remainingTestParameterValuesForFieldInjection) {
             if (declaredField.isAnnotationPresent(
-                testParameterValue.annotationTypeOrigin().annotationType())) {
+                testParameterValue.annotationTypeOrigin().annotationType()) &&
+                declaredField.getName() == testParameterValue.paramName().get()) {
               declaredField.setAccessible(true);
               declaredField.set(testInstance, testParameterValue.unwrappedValue());
               remainingTestParameterValuesForFieldInjection.remove(testParameterValue);
@@ -1275,7 +1276,9 @@ final class TestParameterAnnotationMethodProcessor implements TestMethodProcesso
   private ImmutableList<Method> getMethodsIncludingParents(Class<?> clazz) {
     ImmutableList.Builder<Method> resultBuilder = ImmutableList.builder();
     while (clazz != null) {
-      resultBuilder.add(clazz.getDeclaredMethods());
+      Method[] declaredMethods = clazz.getDeclaredMethods();
+      Arrays.sort(declaredMethods, Comparator.comparing(Method::getName));
+      resultBuilder.add(declaredMethods);
       clazz = clazz.getSuperclass();
     }
     return resultBuilder.build();


### PR DESCRIPTION
I opened this PR to start the conversation with maintainers in modifying the program related to non-deterministic operations.
There are two modules `junit4` and `junit5` in the package, but this PR only modifies the junit4 module before starting the discussion to talk about any concerns in the proposed solution.
We could then modify `junit5` module after we meet an agreement on the `junit4` module.

## What is the purpose of the change?
This PR aims to fix some nondeterministic behaviors in the program `junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java` 
 which is identified by the engine [NonDex](https://github.com/TestingResearchIllinois/NonDex). The program uses implementation-dependent operations such as [`getDeclaredFields()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredFields()) and [`getDeclaredMethods`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredMethods()), which would return arrays not in particular order given different Java version or JVM.

After changing the implementation-dependent [operations](https://github.com/TestingResearchIllinois/NonDex/wiki/Supported-APIs) in Java such as [`getDeclaredFields()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredFields()) or [`getDeclaredMethods`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredMethods()) with NonDex, the nondeterministic behaviors would cause the test failures in the following test classes:
* `com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest`
* `com.google.testing.junit.testparameterinjector.TestParameterTest`
* `com.google.testing.junit.testparameterinjector.TestParametersMethodProcessorTest`
* `com.google.testing.junit.testparameterinjector.ParameterValueParsingTest`

There are three categories of error/failures shown in NonDex logs:

* Assertion fails because parameter values are not in particular order
```
[ERROR] test[DuplicateIdenticalFieldAnnotationTestClass:SUCCESS_ALWAYS](com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest)  Time elapsed: 0.004 s  <<< FAILURE!
java.lang.AssertionError:

----------------------
ImmutableMap.<String, String>builder()
    .put("test[foo,foo]", "foo:foo")
    .put("test[foo,bar]", "foo:bar")
    .put("test[bar,foo]", "foo:bar")
    .put("test[bar,bar]", "bar:bar")
    .build()
----------------------

keys with wrong values
for key       : test[bar,foo]
expected value: bar:foo
but got value : foo:bar
---
expected      : {test[foo,foo]=foo:foo, test[foo,bar]=foo:bar, test[bar,foo]=bar:foo, test[bar,bar]=bar:bar}
but was       : {test[foo,foo]=foo:foo, test[foo,bar]=foo:bar, test[bar,foo]=foo:bar, test[bar,bar]=bar:bar}
        at com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest.test(TestParameterAnnotationMethodProcessorTest.java:833)
Caused by: com.google.common.truth.AssertionErrorWithFacts:

----------------------
ImmutableMap.<String, String>builder()
    .put("test[foo,foo]", "foo:foo")
    .put("test[foo,bar]", "foo:bar")
    .put("test[bar,foo]", "foo:bar")
    .put("test[bar,bar]", "bar:bar")
    .build()
----------------------
```

* Assertion fails because parameter names are not in particular order

```
[ERROR] test[IndependentAnnotation:SUCCESS_ALWAYS](com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest)  Time elapsed: 0.183 s  <<< FAILURE!
java.lang.AssertionError:

----------------------
ImmutableMap.<String, String>builder()
    .put("test[B1,C1,A1]", "A1:B1:C1")
    .put("test[B2,C2,A2]", "A2:B2:C2")
    .put("test[B2,C3,A2]", "A2:B2:C3")
    .build()
----------------------

missing keys
for key         : test[A1,B1,C1]
expected value  : A1:B1:C1
for key         : test[A2,B2,C2]
expected value  : A2:B2:C2
for key         : test[A2,B2,C3]
expected value  : A2:B2:C3
unexpected keys
for key         : test[B1,C1,A1]
unexpected value: A1:B1:C1
for key         : test[B2,C2,A2]
unexpected value: A2:B2:C2
for key         : test[B2,C3,A2]
unexpected value: A2:B2:C3
---
expected        : {test[A1,B1,C1]=A1:B1:C1, test[A2,B2,C2]=A2:B2:C2, test[A2,B2,C3]=A2:B2:C3}
but was         : {test[B1,C1,A1]=A1:B1:C1, test[B2,C2,A2]=A2:B2:C2, test[B2,C3,A2]=A2:B2:C3}
        at com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest.test(TestParameterAnnotationMethodProcessorTest.java:835)
Caused by: com.google.common.truth.AssertionErrorWithFacts:

----------------------
```

* Errors because of Index out of bounds
```
<<stringTest[one,number1=2,stringParam=null](com.google.testing.junit.testparameterinjector.TestParameterTest$WithValuesProvider)>> java.lang.ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 4
        at com.google.common.collect.RegularImmutableList.get(RegularImmutableList.java:77)
        at com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessor.getParameterValuesForTest(TestParameterAnnotationMethodProcessor.java:785)
        at com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessor.maybeGetTestMethodParameters(TestParameterAnnotationMethodProcessor.java:662)
        at com.google.testing.junit.testparameterinjector.TestMethodProcessorList.lambda$getTestMethodParameters$2(TestMethodProcessorList.java:109)
        at com.google.common.collect.Iterators$6.transform(Iterators.java:828)
        at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52)
        at com.google.common.collect.Iterators$5.computeNext(Iterators.java:671)
        at com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:145)
        at com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:140)
        at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
        at com.google.common.collect.FluentIterable.first(FluentIterable.java:515)
        at com.google.testing.junit.testparameterinjector.TestMethodProcessorList.getTestMethodParameters(TestMethodProcessorList.java:112)
        at com.google.testing.junit.testparameterinjector.PluggableTestRunner.methodInvoker(PluggableTestRunner.java:245)
        at com.google.testing.junit.testparameterinjector.PluggableTestRunner.methodBlock(PluggableTestRunner.java:212)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
...
```

## How to fix them?
The operations [`getDeclaredFields()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredFields()) or [`getDeclaredMethods`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#getDeclaredMethods()) are implementation-dependent operations, and the returned elements in the array are not in particular order based on different Java versions.

This PR sorts the returned arrays of `getDeclaredFields` and `getDeclaredMethods` to prevent nondeterministic behaviors caused by implementation-dependent operations.

### Fix for parameter names or parameter values not in particular order
When setting `remainingTestParameterValuesForFieldInjection` in `postProcessTestInstance `, it will use the following function call chain: `getParameterValuesForMethod -> getAnnotationValuesForUsedAnnotationTypes  -> getAnnotationFromParametersOrTestOrClass`.

One cause of failure is in `getAnnotationFromParametersOrTestOrClass`, in which `getDeclaredFields` returns a values array and it is not in particular order.
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java#L927

In addition, when matching the parameter values, it only checks the type without parameter names.
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java#L1049-L1055

It would cause the assertion failures when two parameters are in the same type as in the test case `com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest$DuplicateIdenticalFieldAnnotationTestClass.test()`
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/test/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessorTest.java#L326-L348

At last, when creating the list `fieldAnnotations` in `calculateAnnotationTypeOrigins`. There is an implementation-dependent operation found in the following code snippet, which will return a list of fields not in particular order
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java#L320-L325

The list of fields `fieldAnnotations` would then be used by the function call chain `getParameterValuesForTest -> getParameterValuesForMethod -> getAnnotationValuesForUsedAnnotationTypes -> getAnnotationTypeOrigins`. Among them, the function `getParameterValuesForTest` is extensively used in different functions such as `getTestParameterValues`, `maybeGetConstructorParameters`, `maybeGetTestMethodParameters`, and `postProcessTestInstance`, which would at last cause the parameter names non-deterministic.

### Fix for index out of bound error
The error happened because the cache value returned from `getParameterValuesForMethod(testMethod, testClass)` is not as expected. When query the cache from `getParameterValuesForMethod` with the key `testMethod`, `testMethod` is nondeterministic.
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java#L783C2-L785

`testMethod` is nondeterministic because there is an implementation-dependent operation `getDeclaredMethods` in the following code snippet. It will returns the methods array which is not in particular order.
https://github.com/google/TestParameterInjector/blob/5d67f8cb66481638bcd117227bd0103c32c84491/junit4/src/main/java/com/google/testing/junit/testparameterinjector/TestParameterAnnotationMethodProcessor.java#L1275-L1278

Would you have any concern when fixing the above failures/errors by sorting the result of these nondeterministic functions?

## How to verify the change?
Test environment:
```
openjdk version "11.0.20.1"
Apache Maven 3.8.8
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```

Command:
```
mvn -pl junit4 edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<TEST-CLASS> -Drat.skip=true -DnondexRuns=<NUM_RUNS>
```
replace the `<NUM_RUNS>` with an integer number of runs to change different implementation.
replace the `<TEST-CLASS>` with one of the following test classes:
* `com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest`
* `com.google.testing.junit.testparameterinjector.TestParameterTest`
* `com.google.testing.junit.testparameterinjector.TestParametersMethodProcessorTest`
* `com.google.testing.junit.testparameterinjector.ParameterValueParsingTest`

For example,
```
mvn -pl junit4 edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest -Drat.skip=true -DnondexRuns=5
```
It will runs the test `com.google.testing.junit.testparameterinjector.TestParameterAnnotationMethodProcessorTest` for 5 times with different implementation.

Note that some tests running with NonDex will still fail, because, after discussion below, we decided to only fix some of non-deterministic operations instead of all of them.